### PR TITLE
Add CI to run maven tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: pass-docker-services Continuous Integration
+on: [pull_request]
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  print-workflow-description:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
+      - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
+
+  call-tests-unit:
+    name: Run Automated Tests
+    uses: eclipse-pass/pass-deposit-services/.github/workflows/tests-unit.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
       - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
 
   call-tests-unit:
-    name: Run Automated Tests
+    name: Run Unit Tests
     uses: eclipse-pass/pass-deposit-services/.github/workflows/tests-unit.yml@main

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,0 +1,23 @@
+name: Run Integration Tests
+on:
+  schedule:
+    - cron: '0 3 * * *' # daily, at 3am
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run unit tests
+        run: mvn -B verify --file pom.xml

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,5 +1,6 @@
 name: Run Integration Tests
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 3 * * *' # daily, at 3am
 

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -1,0 +1,22 @@
+name: Run Automated Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run unit tests
+        run: mvn -B test --file pom.xml

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -1,4 +1,4 @@
-name: Run Automated Tests
+name: Run Unit Tests
 on:
   workflow_call
 


### PR DESCRIPTION
Based on (if PR merged, then change to `main`)
https://github.com/eclipse-pass/main/blob/174-pipeline-documentation/docs/pipeline.md

Integrating the `mvn test` into GH actions.  Pinged @markpatton directly for some help deciphering the error messages.