### PR TITLE
Remove DASH repository from sample files.

### DIFF
--- a/shared-resources/src/main/resources/submissions/sample-metadata1.json
+++ b/shared-resources/src/main/resources/submissions/sample-metadata1.json
@@ -9,8 +9,7 @@
     "repositories": [
       "fake:repository1",
       "fake:repository2",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user2",
     "grants": [
@@ -65,13 +64,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample-metadata2.json
+++ b/shared-resources/src/main/resources/submissions/sample-metadata2.json
@@ -9,8 +9,7 @@
     "repositories": [
       "fake:repository1",
       "fake:repository2",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user2",
     "grants": [
@@ -65,13 +64,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample1-no-files.json
+++ b/shared-resources/src/main/resources/submissions/sample1-no-files.json
@@ -10,8 +10,7 @@
     "repositories": [
       "fake:repository1",
       "fake:repository2",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user2",
     "grants": [
@@ -66,13 +65,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample1-unsubmitted.json
+++ b/shared-resources/src/main/resources/submissions/sample1-unsubmitted.json
@@ -10,8 +10,7 @@
     "repositories": [
       "fake:repository1",
       "fake:repository2",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user2",
     "grants": [
@@ -66,13 +65,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample1.json
+++ b/shared-resources/src/main/resources/submissions/sample1.json
@@ -11,8 +11,7 @@
       "fake:repository1",
       "fake:repository2",
       "fake:repository3",
-      "fake:repository4",
-      "fake:repository5"
+      "fake:repository4"
     ],
     "submitter": "fake:user2",
     "grants": [
@@ -78,13 +77,6 @@
     "description": "Web-Link only repository",
     "integrationType": "web-link",
     "@id": "fake:repository4",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository5",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample3-add-figure-and-tables.json
+++ b/shared-resources/src/main/resources/submissions/sample3-add-figure-and-tables.json
@@ -58,13 +58,6 @@
     "@type": "Repository"
   },
   {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
-    "@type": "Repository"
-  },
-  {
     "awardNumber": "R01EY026617",
     "awardStatus": "active",
     "localKey": "112233",

--- a/shared-resources/src/main/resources/submissions/sample3-missing-common-md-fields.json
+++ b/shared-resources/src/main/resources/submissions/sample3-missing-common-md-fields.json
@@ -9,8 +9,7 @@
     "publication": "fake:publication1",
     "repositories": [
       "fake:repository1",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user1",
     "grants": [
@@ -55,13 +54,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample3-missing-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-missing-doi.json
@@ -9,8 +9,7 @@
     "publication": "fake:publication1",
     "repositories": [
       "fake:repository1",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user1",
     "grants": [
@@ -54,13 +53,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample3-null-common-md-fields.json
+++ b/shared-resources/src/main/resources/submissions/sample3-null-common-md-fields.json
@@ -10,8 +10,7 @@
     "repositories": [
       "fake:repository1",
       "fake:repository2",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user1",
     "grants": [
@@ -56,13 +55,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample3-null-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-null-doi.json
@@ -9,8 +9,7 @@
     "publication": "fake:publication1",
     "repositories": [
       "fake:repository1",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user1",
     "grants": [
@@ -54,13 +53,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample3-untrimmed-doi.json
+++ b/shared-resources/src/main/resources/submissions/sample3-untrimmed-doi.json
@@ -9,8 +9,7 @@
     "publication": "fake:publication1",
     "repositories": [
       "fake:repository1",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user1",
     "grants": [
@@ -55,13 +54,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample3.json
+++ b/shared-resources/src/main/resources/submissions/sample3.json
@@ -9,8 +9,7 @@
     "publication": "fake:publication1",
     "repositories": [
       "fake:repository1",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user1",
     "grants": [
@@ -55,13 +54,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample4-unsubmitted-1repo.json
+++ b/shared-resources/src/main/resources/submissions/sample4-unsubmitted-1repo.json
@@ -9,8 +9,7 @@
     "publication": "fake:publication1",
     "repositories": [
       "fake:repository2",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user2",
     "grants": [
@@ -56,13 +55,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample5-incompleteissn.json
+++ b/shared-resources/src/main/resources/submissions/sample5-incompleteissn.json
@@ -10,8 +10,7 @@
     "repositories": [
       "fake:repository1",
       "fake:repository2",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user2",
     "grants": [
@@ -57,13 +56,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {

--- a/shared-resources/src/main/resources/submissions/sample6-semi-incompleteissn.json
+++ b/shared-resources/src/main/resources/submissions/sample6-semi-incompleteissn.json
@@ -10,8 +10,7 @@
     "repositories": [
       "fake:repository1",
       "fake:repository2",
-      "fake:repository3",
-      "fake:repository4"
+      "fake:repository3"
     ],
     "submitter": "fake:user2",
     "grants": [
@@ -57,13 +56,6 @@
     "repositoryKey": "BagIt",
     "description": "Repository for storing bags",
     "@id": "fake:repository3",
-    "@type": "Repository"
-  },
-  {
-    "name": "DASH Repo",
-    "repositoryKey": "dash",
-    "description": "DASH repository",
-    "@id": "fake:repository4",
     "@type": "Repository"
   },
   {


### PR DESCRIPTION
PASS deposit services has DASH repositories referenced in sample submissions used for tests. That DASH repository support never made into main of pass-package-providers and so makes the pass-package-providers ITs fail.
See https://github.com/eclipse-pass/pass-package-providers/pull/48.
